### PR TITLE
Only consider packages that contain java files.

### DIFF
--- a/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.exec.OS;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOCase;
 import org.apache.commons.io.filefilter.FalseFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
@@ -245,7 +246,8 @@ public class JavadocRunner {
     private Collection<String> derivePackageNamesFromSourceFolder(File sourceFolder) {
         Collection<File> containedDirectories = FileUtils
                 .listFilesAndDirs(sourceFolder, FalseFileFilter.INSTANCE, TrueFileFilter.INSTANCE).stream()
-                .filter(f -> f.listFiles(((FilenameFilter) new SuffixFileFilter(".java"))::accept).length > 0)
+                .filter(f -> f.listFiles(
+                        ((FilenameFilter) new SuffixFileFilter(".java", IOCase.INSENSITIVE))::accept).length > 0)
                 .collect(Collectors.toList());
         Path sourcePath = sourceFolder.toPath();
         return containedDirectories.stream().map(File::toPath).map(p -> sourcePath.relativize(p)).map(Path::toString)

--- a/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
@@ -12,6 +12,7 @@
 package org.eclipse.tycho.extras.docbundle;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -23,6 +24,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.exec.OS;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FalseFileFilter;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -243,7 +245,8 @@ public class JavadocRunner {
     private Collection<String> derivePackageNamesFromSourceFolder(File sourceFolder) {
         Collection<File> containedDirectories = FileUtils
                 .listFilesAndDirs(sourceFolder, FalseFileFilter.INSTANCE, TrueFileFilter.INSTANCE).stream()
-                .filter(f -> f.listFiles(File::isFile).length > 0).collect(Collectors.toList());
+                .filter(f -> f.listFiles(((FilenameFilter) new SuffixFileFilter(".java"))::accept).length > 0)
+                .collect(Collectors.toList());
         Path sourcePath = sourceFolder.toPath();
         return containedDirectories.stream().map(File::toPath).map(p -> sourcePath.relativize(p)).map(Path::toString)
                 .map(s -> s.replaceAll(Pattern.quote(File.separator), ".")).collect(Collectors.toSet());


### PR DESCRIPTION
This PR fixes a bug that causes javadoc to crash when a package contains only files that are no source files.