### PR TITLE
Apply the patch from tycho master for finding classpath entries.

### DIFF
--- a/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.execution.MavenSession;
@@ -29,6 +30,9 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.tycho.classpath.ClasspathEntry;
+import org.eclipse.tycho.core.BundleProject;
+import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.osgitools.BundleReader;
 
 /**
@@ -186,6 +190,8 @@ public class JavadocMojo extends AbstractMojo {
     @Component
     private DocletArtifactsResolver docletArtifactsResolver;
 
+    @Component(role = TychoProject.class)
+    private Map<String, TychoProject> projectTypes;
     public void setTocOptions(TocOptions tocOptions) {
         this.tocOptions = tocOptions;
     }
@@ -236,7 +242,6 @@ public class JavadocMojo extends AbstractMojo {
             getLog().info("Source folder: " + file);
         }
 
-        // TODO: use tycho's approach of gathering the classpath
         final GatherClasspathVisitor gcv = new GatherClasspathVisitor();
         visitProjects(this.session.getCurrentProject().getDependencies(), this.scopes, gcv);
 
@@ -339,10 +344,20 @@ public class JavadocMojo extends AbstractMojo {
     private class GatherClasspathVisitor implements ProjectVisitor {
         private final Set<String> classPath = new HashSet<>();
 
+        private BundleProject getBundleProject(final MavenProject project) throws MojoExecutionException {
+            TychoProject projectType = projectTypes.get(project.getPackaging());
+            if (!(projectType instanceof BundleProject)) {
+                return null;
+            }
+            return (BundleProject) projectType;
+        }
+
+        @Override
         public void visit(final MavenProject project) throws MojoExecutionException {
-            for (final Dependency dep : (List<Dependency>) project.getDependencies()) {
-                if (dep.getSystemPath() != null) {
-                    this.classPath.add(dep.getSystemPath());
+            final BundleProject bp = getBundleProject(project);
+            if (bp != null) {
+                for (final ClasspathEntry cpe : bp.getClasspath(project)) {
+                    cpe.getLocations().forEach(location -> this.classPath.add(location.getAbsolutePath()));
                 }
             }
         }


### PR DESCRIPTION
The current version of this maven plugin only considers dependencies that are defined on a project level but not dependencies that are satisfied by embedded JARs and similar stuff. The master branch of the tycho-documentation-plugin already contains a [fix](https://github.com/eclipse/tycho.extras/commit/e2640791dd827bcc3f606d86e7c5c8b3999de1d3) that this pull requests integrates into this plugin.

Adding this patch is necessary because javadoc might exit without generating any output if there are errors in the source code (see [release notes](https://www.oracle.com/technetwork/java/javase/9-notes-3745703.html#JDK-8175219)) starting from JDK 9.