### PR TITLE
Sync with latest version for tycho 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.palladiosimulator</groupId>
 	<artifactId>tycho-document-bundle-plugin</artifactId>
-	<version>1.1.6-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>Tycho Document Bundle Plugin</name>
@@ -55,18 +55,35 @@
 		<url>http://github.com/palladiosimulator/palladio-build-mavenjavadocplugin/tree/master</url>
 	</scm>
 
+	<repositories>
+		<repository>
+			<id>tycho-staging</id>
+		   <url>https://oss.sonatype.org/content/groups/staging/</url>
+		</repository>
+	</repositories> 
+	
+	<pluginRepositories>
+		<pluginRepository>
+		   <id>tycho-staging</id>
+		   <url>https://oss.sonatype.org/content/groups/staging/</url>
+		</pluginRepository>
+	 </pluginRepositories>
+
 	<properties>
-		<tycho-version>1.3.0</tycho-version>
+		<min.jdk.version>11</min.jdk.version>
+		<tycho-version>2.2.0</tycho-version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<pluginToolsVersion>3.6.0</pluginToolsVersion>
+		<maven-version>3.6.3</maven-version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.5</version>
+			<version>${pluginToolsVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
@@ -95,21 +112,21 @@
 			<version>2.6</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.maven.plugin-testing</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
 			<scope>test</scope>
-			<version>2.0</version>
+			<version>3.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.7.0</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
+			<artifactId>mockito-core</artifactId>
+			<version>3.6.28</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -161,8 +178,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.4</version>
-			</plugin>
+				<version>${pluginToolsVersion}</version>
+				<configuration>
+				  <requirements>
+					<maven>${maven-version}</maven>
+					<jdk>${min.jdk.version}</jdk>
+				  </requirements>
+				</configuration>
+			  </plugin>
 			<plugin>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-component-metadata</artifactId>
@@ -192,7 +215,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>

--- a/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocMojo.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2013, 2019 IBH SYSTEMS GmbH and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
@@ -34,20 +36,15 @@ import org.eclipse.tycho.classpath.ClasspathEntry;
 import org.eclipse.tycho.core.BundleProject;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.osgitools.BundleReader;
+import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
 
 /**
- * <p>
- * Create the javadoc based API reference for this bundle
- * </p>
- * <p>
+ * Create the javadoc based API reference for this bundle <br>
  * This mojo creates the javadoc documentation by calling the javadoc application from the command
- * line. In addition it creates a ready to include toc-xml file for the Eclipse Help system.
- * </p>
- * <p>
+ * line. In addition it creates a ready to include toc-xml file for the Eclipse Help system. <br>
  * The sources for creating the javadoc are generated automatically based on the dependency that
  * this project has. As dependency you can specify any other maven project, for example the feature
  * project that references you other bundles. Included features will be added to the list.
- * </p>
  * 
  * @since 0.20.0
  */
@@ -118,30 +115,32 @@ public class JavadocMojo extends AbstractMojo {
      * Example configuration:
      * 
      * <pre>
-     * &lt;configuration&gt;
-     *    &lt;javadocOptions&gt;
-     *       &lt;ignoreError&gt;false&lt;/ignoreError&gt;
-     *       &lt;encoding&gt;UTF-8&lt;/encoding&gt;
-     *       &lt;doclet&gt;foo.bar.MyDoclet&lt;/doclet&gt;
-     *       &lt;docletArtifacts&gt;
-     *          &lt;docletArtifact&gt;
-     *             &lt;groupId&gt;foo.bar&lt;/groupId&gt;
-     *             &lt;artifactId&gt;foo.bar.mydocletartifact&lt;/artifactId&gt;
-     *             &lt;version&gt;1.0&lt;/version&gt;
-     *          &lt;/docletArtifact&gt;
-     *       &lt;/docletArtifacts&gt;
-     *       &lt;includes&gt;
-     *          &lt;include&gt;com.example.*&lt;/include&gt;
-     *       &lt;/includes&gt;
-     *       &lt;excludes&gt;
-     *          &lt;exclude&gt;com.example.internal.*&lt;/exclude&gt;
-     *       &lt;/excludes&gt;   
-     *       &lt;additionalArguments&gt;
-     *          &lt;additionalArgument&gt;-windowtitle "The Window Title"&lt;/additionalArgument&gt;
-     *          &lt;additionalArgument&gt;-nosince&lt;/additionalArgument&gt;
-     *       &lt;/additionalArguments&gt;
-     *    &lt;/javadocOptions&gt;
-     * &lt;/configuration&gt;
+     * {@code
+     * <configuration&gt;
+     *    <javadocOptions>
+     *       <ignoreError>false</ignoreError>
+     *       <encoding>UTF-8</encoding>
+     *       <doclet>foo.bar.MyDoclet</doclet>
+     *       <docletArtifacts>
+     *          <docletArtifact>
+     *             <groupId>foo.bar</groupId>
+     *             <artifactId>foo.bar.mydocletartifact</artifactId>
+     *             <version>1.0</version>
+     *          </docletArtifact>
+     *       </docletArtifacts>
+     *       <includes>
+     *          <include>com.example.*</include>
+     *       </includes>
+     *       <excludes>
+     *          <exclude>com.example.internal.*</exclude>
+     *       </excludes>
+     *       <additionalArguments>
+     *          <additionalArgument>-windowtitle "The Window Title"</additionalArgument>
+     *          <additionalArgument>-nosince</additionalArgument>
+     *       </additionalArguments>
+     *    </javadocOptions>
+     * </configuration>
+     * }
      * </pre>
      */
     @Parameter(property = "javadocOptions")
@@ -150,7 +149,8 @@ public class JavadocMojo extends AbstractMojo {
     /**
      * Options for creating the toc files.
      * <ul>
-     * <li><tt>mainLabel</tt>, specifies the main label of the toc file (default: "API Reference")</li>
+     * <li><tt>mainLabel</tt>, specifies the main label of the toc file (default: "API Reference")
+     * </li>
      * <li><tt>mainFilename</tt>, specifies the filename of the TOC file (default:
      * "overview-summary.html")
      * </ul>
@@ -198,6 +198,7 @@ public class JavadocMojo extends AbstractMojo {
 
     @Component(role = TychoProject.class)
     private Map<String, TychoProject> projectTypes;
+
     public void setTocOptions(TocOptions tocOptions) {
         this.tocOptions = tocOptions;
     }
@@ -327,6 +328,7 @@ public class JavadocMojo extends AbstractMojo {
     private class GatherSourcesVisitor implements ProjectVisitor {
         private final Set<File> sourceFolders = new HashSet<>();
 
+        @Override
         public void visit(final MavenProject project) {
             if (JavadocMojo.this.sourceTypes.contains(project.getPackaging())) {
                 for (final String root : (Collection<String>) project.getCompileSourceRoots()) {
@@ -347,6 +349,7 @@ public class JavadocMojo extends AbstractMojo {
     private class GatherManifestVisitor implements ProjectVisitor {
         private final Set<File> manifestFiles = new HashSet<>();
 
+        @Override
         public void visit(final MavenProject project) {
             if (JavadocMojo.this.sourceTypes.contains(project.getPackaging())) {
                 this.manifestFiles.add(new File(project.getBasedir(), "META-INF/MANIFEST.MF"));
@@ -373,7 +376,7 @@ public class JavadocMojo extends AbstractMojo {
         public void visit(final MavenProject project) throws MojoExecutionException {
             final BundleProject bp = getBundleProject(project);
             if (bp != null) {
-                for (final ClasspathEntry cpe : bp.getClasspath(project)) {
+                for (final ClasspathEntry cpe : bp.getClasspath(DefaultReactorProject.adapt(project))) {
                     cpe.getLocations().forEach(location -> this.classPath.add(location.getAbsolutePath()));
                 }
             }

--- a/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocOptions.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocOptions.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2013, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
@@ -16,13 +18,9 @@ import java.util.List;
 import org.apache.maven.model.Dependency;
 
 /**
- * <p>
- * The javadoc options
- * </p>
- * <p>
+ * The javadoc options<br>
  * At the moment the list of real options is quite small, but most arguments can be passed using the
  * <code>additionalArguments</code> property.
- * </p>
  * 
  * @author Jens Reimann
  */

--- a/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/JavadocRunner.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2013, 2020 IBH SYSTEMS GmbH and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
@@ -107,8 +109,7 @@ public class JavadocRunner {
         final File optionsFile = new File(this.buildDirectory, "javadoc.options.txt");
         final Commandline cli = createCommandLine(optionsFile.getAbsolutePath());
 
-        final PrintStream ps = new PrintStream(optionsFile);
-        try {
+        try (PrintStream ps = new PrintStream(optionsFile)) {
             ps.print(createOptionsFileContent());
             ps.close();
 
@@ -121,8 +122,6 @@ public class JavadocRunner {
                     this.log.info("execution failed with rc = " + rc);
                 }
             }
-        } finally {
-            ps.close();
         }
     }
 

--- a/src/main/java/org/eclipse/tycho/extras/docbundle/TocOptions.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/TocOptions.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2013, 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/src/main/java/org/eclipse/tycho/extras/docbundle/TocWriter.java
+++ b/src/main/java/org/eclipse/tycho/extras/docbundle/TocWriter.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
  * Copyright (c) 2013, 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
@@ -105,15 +107,16 @@ public class TocWriter {
         createTopic(doc, main, "Constant Values", "constant-values.html");
         createTopic(doc, main, "Deprecated List", "deprecated-list.html");
 
-        final LineNumberReader reader = new LineNumberReader(new FileReader(new File(this.javadocDir, "package-list")));
-        try {
+        File packageList = new File(this.javadocDir, "package-list");
+        if (!packageList.exists()) {
+            packageList = new File(this.javadocDir, "element-list");
+        }
+        try (LineNumberReader reader = new LineNumberReader(new FileReader(packageList))) {
             String line;
 
             while ((line = reader.readLine()) != null) {
                 createTopic(doc, packages, line, line.replace('.', '/') + "/package-summary.html");
             }
-        } finally {
-            reader.close();
         }
     }
 

--- a/src/test/java/org/eclipse/tycho/extras/docbundle/AssertOnBuffer.java
+++ b/src/test/java/org/eclipse/tycho/extras/docbundle/AssertOnBuffer.java
@@ -1,16 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2015 VDS Rail and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2015, 2020 VDS Rail and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *    Enrico De Fent - initial API and implementation
  *******************************************************************************/
 package org.eclipse.tycho.extras.docbundle;
 
-import org.junit.Assert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class AssertOnBuffer {
     final String[] lines;
@@ -20,25 +23,25 @@ class AssertOnBuffer {
     public AssertOnBuffer(String buffer) {
         this.buffer = buffer;
 
-        String lineSeparator = System.getProperty("line.separator");
+        String lineSeparator = System.lineSeparator();
         this.lines = buffer.split(lineSeparator);
     }
 
     public void assertMoreLines() {
         if (curLine == lines.length) {
-            Assert.fail("expected more lines, found no more");
+            fail("expected more lines, found no more");
         }
     }
 
     public void assertNextLine(String line) {
         assertMoreLines();
-        Assert.assertEquals("at line " + curLine, line, lines[curLine]);
+        assertEquals(line, lines[curLine], "at line " + curLine);
         curLine++;
     }
 
     public void assertNoMoreLines() {
         if (curLine < lines.length) {
-            Assert.fail(String.format("expected no more lines, found %d more", lines.length - curLine));
+            fail(String.format("expected no more lines, found %d more", lines.length - curLine));
         }
     }
 }

--- a/src/test/java/org/eclipse/tycho/extras/docbundle/PackageNameMatcherTest.java
+++ b/src/test/java/org/eclipse/tycho/extras/docbundle/PackageNameMatcherTest.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2015 VDS Rail and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2015, 2020 VDS Rail and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *    Enrico De Fent - initial API and implementation
@@ -11,14 +13,15 @@
 package org.eclipse.tycho.extras.docbundle;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PackageNameMatcherTest {
 
@@ -65,9 +68,7 @@ public class PackageNameMatcherTest {
 
     @Test
     public void testPattern05() {
-        final List<String> specs = new ArrayList<>();
-        specs.add("com.example.*");
-        specs.add("org.example.*");
+        final List<String> specs = List.of("com.example.*", "org.example.*");
         PackageNameMatcher matcher = PackageNameMatcher.compile(specs);
         assertFalse(matcher.matches("com.example"));
         assertTrue(matcher.matches("com.example.pkg"));
@@ -77,27 +78,25 @@ public class PackageNameMatcherTest {
         assertTrue(matcher.matches("org.example.pkg.sub"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPattern06() {
-        PackageNameMatcher.compile(asList("com.example.!"));
+        assertThrows(IllegalArgumentException.class, () -> PackageNameMatcher.compile(asList("com.example.!")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPattern07() {
-        final List<String> specs = new ArrayList<>();
-        specs.add("com.example.*");
-        specs.add("org.example.!");
-        PackageNameMatcher.compile(specs);
+        final List<String> specs = List.of("com.example.*", "org.example.!");
+        assertThrows(IllegalArgumentException.class, () -> PackageNameMatcher.compile(specs));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSpacesPattern01() {
-        PackageNameMatcher.compile(asList("  "));
+        assertThrows(IllegalArgumentException.class, () -> PackageNameMatcher.compile(asList("  ")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSpacesPattern02() {
-        PackageNameMatcher.compile(asList("\t\t"));
+        assertThrows(IllegalArgumentException.class, () -> PackageNameMatcher.compile(asList("\t\t")));
     }
 
 }

--- a/src/test/java/org/eclipse/tycho/extras/docbundle/TestJavadocRunner.java
+++ b/src/test/java/org/eclipse/tycho/extras/docbundle/TestJavadocRunner.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2015 Obeo and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2014, 2020 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Obeo - initial API and implementation
@@ -11,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.extras.docbundle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,8 +30,7 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.eclipse.tycho.core.osgitools.DefaultBundleReader;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestJavadocRunner {
 
@@ -42,9 +44,9 @@ public class TestJavadocRunner {
         Commandline commandLine = javadocRunner.createCommandLine("/dev/null");
 
         String[] cliArgs = commandLine.getArguments();
-        Assert.assertEquals(2, cliArgs.length);
-        Assert.assertEquals("@/dev/null", cliArgs[0]);
-        Assert.assertEquals("-J-Xmx512m", cliArgs[1]);
+        assertEquals(2, cliArgs.length);
+        assertEquals("@/dev/null", cliArgs[0]);
+        assertEquals("-J-Xmx512m", cliArgs[1]);
     }
 
     @Test
@@ -53,8 +55,8 @@ public class TestJavadocRunner {
         JavadocOptions options = new JavadocOptions();
         List<Dependency> docletArifacts = new LinkedList<>();
         DocletArtifactsResolver docletResolver = mock(DocletArtifactsResolver.class);
-        Set<String> docletArtifactsJarList = new LinkedHashSet<>(Arrays.asList("path/to/docletArtifact.jar",
-                "path/to/otherDocletArtifact.jar"));
+        Set<String> docletArtifactsJarList = new LinkedHashSet<>(
+                Arrays.asList("path/to/docletArtifact.jar", "path/to/otherDocletArtifact.jar"));
         when(docletResolver.resolveArtifacts(docletArifacts)).thenReturn(docletArtifactsJarList);
         options.setAdditionalArguments(Arrays.asList("-docencoding \"UTF-8\""));
         options.setDoclet("foo.bar.MyDoclet");
@@ -70,8 +72,8 @@ public class TestJavadocRunner {
         AssertOnBuffer aob = new AssertOnBuffer(optionsFile);
         aob.assertNextLine("-classpath 'rt.jar'");
         aob.assertNextLine("-doclet foo.bar.MyDoclet");
-        aob.assertNextLine("-docletpath 'path/to/docletArtifact.jar" + File.pathSeparator
-                + "path/to/otherDocletArtifact.jar'");
+        aob.assertNextLine(
+                "-docletpath 'path/to/docletArtifact.jar" + File.pathSeparator + "path/to/otherDocletArtifact.jar'");
         aob.assertNextLine("-encoding ISO8859_1");
         aob.assertNextLine("-docencoding \"UTF-8\"");
         aob.assertNextLine("com.example.bundle.core");


### PR DESCRIPTION
Synced with the latest commit for release 2.2.0 on the tycho master branch. Tycho 2.2.0 is required to run JUnit 5 Tests using Extensions in Eclipse 2020/12 builds. The major changes as far as I could see:

- Adapt MavenProject to ReactorProject (this one is actually required)
- Use try-with instead of try-finally.
- Switch from Junit4 to 5
- Update license to EPL v2

There is currently a dependency to the 2.2.0 staged release version which can be removed, once the release is available via Maven Central (ETA 18.01.2020).